### PR TITLE
Fix: Issue #5 - Play a little trick: CentOS/RHEL系多重检测结果时，以较大版本值为准

### DIFF
--- a/LemonBench.sh
+++ b/LemonBench.sh
@@ -415,7 +415,7 @@ function BenchAPI_Systeminfo_GetOSReleaseinfo() {
     if [ -f "/etc/centos-release" ] || [ -f "/etc/redhat-release" ]; then
         Result_Systeminfo_OSReleaseNameShort="centos"
         local r_prettyname && r_prettyname="$(grep -oP '(?<=\bPRETTY_NAME=").*(?=")' /etc/os-release)"
-        local r_elrepo_version && r_elrepo_version="$(rpm -qa | grep -oP "el[0-9]+" | sort -u)"
+        local r_elrepo_version && r_elrepo_version="$(rpm -qa | grep -oP "el[0-9]+" | sort -ur | head -n1)"
         case "$r_elrepo_version" in
         9 | el9)
             Result_Systeminfo_OSReleaseVersionShort="9"


### PR DESCRIPTION
根据 Issue #5 的信息，尝试做下小修改

原来情况下，仅仅会进行简单去重，如果出现混包情况下（如CentOS Stream 8/9）出现多个版本，则以最高版本为准